### PR TITLE
integrated task key field

### DIFF
--- a/task-harbour/src/components/taskList/taskList.js
+++ b/task-harbour/src/components/taskList/taskList.js
@@ -127,6 +127,13 @@ function ProjectCreation() {
             field: 'taskKey',
             headerName: 'Task Key',
             flex: 1,
+            renderCell: (params) => {
+                if (typeof params.value === 'string'){
+                    return params.value
+                }else{
+                    return "N/A"
+                }
+            }
         },
         // {
         //     field: 'TaskID', 


### PR DESCRIPTION
Screenshot of change (field second from the left)
Some task keys show "N/A" this is a condition set to handle tasks with no task keys but shows (Object object) instead

Object object is due to a whole payload being persist to the taskKey field in DynamoDB.  This is because the task keys features need a migration of DynamoDB, some projects do not have the fields required (projectKey and taskSequence)

![image](https://github.com/shameerrehman/CPS714-Project/assets/16711168/47531b1f-cc69-446e-9970-ba90580490d7)
